### PR TITLE
Fix/#11 네트워크 통신 로직 리팩토링

### DIFF
--- a/MeaningOut.xcodeproj/project.pbxproj
+++ b/MeaningOut.xcodeproj/project.pbxproj
@@ -39,7 +39,7 @@
 		BE3FE3D22C1D883A00F58754 /* ProfileImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3FE3D12C1D883A00F58754 /* ProfileImage.swift */; };
 		BE3FE3D42C1D894D00F58754 /* ProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3FE3D32C1D894D00F58754 /* ProfileImageView.swift */; };
 		BE3FE3D62C1DB65C00F58754 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3FE3D52C1DB65C00F58754 /* TabBarController.swift */; };
-		BE3FE3D82C1DB6CA00F58754 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3FE3D72C1DB6CA00F58754 /* SearchViewController.swift */; };
+		BE3FE3D82C1DB6CA00F58754 /* SearchHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3FE3D72C1DB6CA00F58754 /* SearchHistoryViewController.swift */; };
 		BE3FE3DA2C1DB6F800F58754 /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3FE3D92C1DB6F800F58754 /* SettingViewController.swift */; };
 		BE3FE3DC2C1DB95C00F58754 /* EmptySearchHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3FE3DB2C1DB95C00F58754 /* EmptySearchHistoryView.swift */; };
 		BE3FE3DE2C1DBB5600F58754 /* SearchHistoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3FE3DD2C1DBB5600F58754 /* SearchHistoryItem.swift */; };
@@ -55,6 +55,10 @@
 		BE3FE3FA2C1EDDA300F58754 /* NaverSearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3FE3F92C1EDDA300F58754 /* NaverSearchResponse.swift */; };
 		BE3FE4002C1EE40000F58754 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3FE3FF2C1EE40000F58754 /* String+.swift */; };
 		BE3FE4032C1EE7B200F58754 /* NaverSearchResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = BE3FE4022C1EE7B200F58754 /* NaverSearchResponse.json */; };
+		BE76B3712C2E783B00CEE3BA /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE76B3702C2E783B00CEE3BA /* NetworkService.swift */; };
+		BE76B3732C2FE77F00CEE3BA /* DataRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE76B3722C2FE77F00CEE3BA /* DataRequest.swift */; };
+		BE76B3752C2FE78E00CEE3BA /* RequestStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE76B3742C2FE78E00CEE3BA /* RequestStorage.swift */; };
+		BE76B3772C2FE7A000CEE3BA /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE76B3762C2FE7A000CEE3BA /* NetworkError.swift */; };
 		BEBFC3A02C2173DE00F35E82 /* ProfileViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBFC39F2C2173DE00F35E82 /* ProfileViewType.swift */; };
 		BEBFC3A22C21785C00F35E82 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBFC3A12C21785C00F35E82 /* UIFont+.swift */; };
 		BEBFC3A42C217B4500F35E82 /* UICollectionView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBFC3A32C217B4500F35E82 /* UICollectionView+.swift */; };
@@ -101,7 +105,7 @@
 		BE3FE3D12C1D883A00F58754 /* ProfileImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImage.swift; sourceTree = "<group>"; };
 		BE3FE3D32C1D894D00F58754 /* ProfileImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageView.swift; sourceTree = "<group>"; };
 		BE3FE3D52C1DB65C00F58754 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
-		BE3FE3D72C1DB6CA00F58754 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
+		BE3FE3D72C1DB6CA00F58754 /* SearchHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryViewController.swift; sourceTree = "<group>"; };
 		BE3FE3D92C1DB6F800F58754 /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		BE3FE3DB2C1DB95C00F58754 /* EmptySearchHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptySearchHistoryView.swift; sourceTree = "<group>"; };
 		BE3FE3DD2C1DBB5600F58754 /* SearchHistoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryItem.swift; sourceTree = "<group>"; };
@@ -118,6 +122,10 @@
 		BE3FE3F92C1EDDA300F58754 /* NaverSearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaverSearchResponse.swift; sourceTree = "<group>"; };
 		BE3FE3FF2C1EE40000F58754 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		BE3FE4022C1EE7B200F58754 /* NaverSearchResponse.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = NaverSearchResponse.json; sourceTree = "<group>"; };
+		BE76B3702C2E783B00CEE3BA /* NetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
+		BE76B3722C2FE77F00CEE3BA /* DataRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataRequest.swift; sourceTree = "<group>"; };
+		BE76B3742C2FE78E00CEE3BA /* RequestStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestStorage.swift; sourceTree = "<group>"; };
+		BE76B3762C2FE7A000CEE3BA /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		BEBFC39F2C2173DE00F35E82 /* ProfileViewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewType.swift; sourceTree = "<group>"; };
 		BEBFC3A12C21785C00F35E82 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
 		BEBFC3A32C217B4500F35E82 /* UICollectionView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+.swift"; sourceTree = "<group>"; };
@@ -236,6 +244,7 @@
 				BE3FE3A82C1BC4BE00F58754 /* UserDefaultsWrapper.swift */,
 				BE3FE3DF2C1DBBC000F58754 /* ReuseIdentifiable.swift */,
 				BE3FE3C12C1C34AC00F58754 /* DesignConstant.swift */,
+				BE76B33B2C2D12EF00CEE3BA /* Network */,
 				BEF7F96D2C20702700136FBA /* Validation */,
 				BEF7F9692C2065F900136FBA /* Secret */,
 				BEF7F9682C2065E500136FBA /* Debugging */,
@@ -350,10 +359,21 @@
 			path = Mock;
 			sourceTree = "<group>";
 		};
+		BE76B33B2C2D12EF00CEE3BA /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				BE76B3702C2E783B00CEE3BA /* NetworkService.swift */,
+				BE76B3762C2FE7A000CEE3BA /* NetworkError.swift */,
+				BE76B3722C2FE77F00CEE3BA /* DataRequest.swift */,
+				BE76B3742C2FE78E00CEE3BA /* RequestStorage.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
 		BEF7F9262C1EF9B400136FBA /* History */ = {
 			isa = PBXGroup;
 			children = (
-				BE3FE3D72C1DB6CA00F58754 /* SearchViewController.swift */,
+				BE3FE3D72C1DB6CA00F58754 /* SearchHistoryViewController.swift */,
 				BEF7F9612C20643D00136FBA /* View */,
 			);
 			path = History;
@@ -552,6 +572,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BE3FE37D2C1B01B600F58754 /* OnboardingMainViewController.swift in Sources */,
+				BE76B3772C2FE7A000CEE3BA /* NetworkError.swift in Sources */,
 				BE3FE3DE2C1DBB5600F58754 /* SearchHistoryItem.swift in Sources */,
 				BEBFC3A42C217B4500F35E82 /* UICollectionView+.swift in Sources */,
 				BE3FE3DA2C1DB6F800F58754 /* SettingViewController.swift in Sources */,
@@ -560,6 +581,7 @@
 				BE3FE3CA2C1D7D4B00F58754 /* NicknameValidator.swift in Sources */,
 				BE3FE3EE2C1EB4CD00F58754 /* SearchResultViewController.swift in Sources */,
 				BE3FE3DC2C1DB95C00F58754 /* EmptySearchHistoryView.swift in Sources */,
+				BE76B3732C2FE77F00CEE3BA /* DataRequest.swift in Sources */,
 				BE3FE3AE2C1BC96500F58754 /* User.swift in Sources */,
 				BE3FE3BF2C1C33F100F58754 /* ProfileButton.swift in Sources */,
 				BE3FE3CC2C1D7D8B00F58754 /* BaseViewController.swift in Sources */,
@@ -593,7 +615,9 @@
 				BE3FE3E42C1DC4F200F58754 /* SearchHistoryHeaderView.swift in Sources */,
 				BE3FE3FA2C1EDDA300F58754 /* NaverSearchResponse.swift in Sources */,
 				8EDCB8D92C2C6F13006F7851 /* BaseView.swift in Sources */,
-				BE3FE3D82C1DB6CA00F58754 /* SearchViewController.swift in Sources */,
+				BE3FE3D82C1DB6CA00F58754 /* SearchHistoryViewController.swift in Sources */,
+				BE76B3752C2FE78E00CEE3BA /* RequestStorage.swift in Sources */,
+				BE76B3712C2E783B00CEE3BA /* NetworkService.swift in Sources */,
 				BE3FE3D22C1D883A00F58754 /* ProfileImage.swift in Sources */,
 				BEF7F96C2C20702500136FBA /* NaverSearchValidator.swift in Sources */,
 				BE3FE3CE2C1D811500F58754 /* ProfileImageViewController.swift in Sources */,

--- a/MeaningOut/Sources/Presentation/MainTab/Search/History/SearchHistoryViewController.swift
+++ b/MeaningOut/Sources/Presentation/MainTab/Search/History/SearchHistoryViewController.swift
@@ -1,5 +1,5 @@
 //
-//  SearchViewController.swift
+//  SearchHistoryViewController.swift
 //  MeaningOut
 //
 //  Created by gnksbm on 6/15/24.
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-final class SearchViewController: BaseViewController {
+final class SearchHistoryViewController: BaseViewController {
     private var dataSource: DataSource!
     
     private lazy var headerViewHeightConstraint =
@@ -86,7 +86,7 @@ final class SearchViewController: BaseViewController {
 }
 
 // MARK: UITableView
-extension SearchViewController {
+extension SearchHistoryViewController {
     private func updateSnapshot(items: [SearchHistoryItem]) {
         var snapshot = Snapshot()
         tableView.backgroundView = items.isEmpty ?
@@ -144,7 +144,7 @@ extension SearchViewController {
 }
 
 // MARK: UITableViewDelegate
-extension SearchViewController: UITableViewDelegate {
+extension SearchHistoryViewController: UITableViewDelegate {
     func tableView(
         _ tableView: UITableView,
         didSelectRowAt indexPath: IndexPath
@@ -157,7 +157,7 @@ extension SearchViewController: UITableViewDelegate {
 }
 
 // MARK: UISearchBarDelegate
-extension SearchViewController: UISearchBarDelegate {
+extension SearchHistoryViewController: UISearchBarDelegate {
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let query = searchBar.text else {
             Logger.debugging("searchBar.text 옵셔널 바인딩 실패")
@@ -171,11 +171,11 @@ extension SearchViewController: UISearchBarDelegate {
 import SwiftUI
 struct SearchViewControllerPreview: PreviewProvider {
     static var previews: some View {
-        SearchViewController().swiftUIViewWithNavigation
+        SearchHistoryViewController().swiftUIViewWithNavigation
             .onAppear {
                 User.currentHistory = []
             }
-        SearchViewController().swiftUIViewWithNavigation
+        SearchHistoryViewController().swiftUIViewWithNavigation
             .onAppear {
                 User.currentHistory = .mock
             }

--- a/MeaningOut/Sources/Presentation/MainTab/Search/History/View/Cell/SearchHistoryItemTVCell.swift
+++ b/MeaningOut/Sources/Presentation/MainTab/Search/History/View/Cell/SearchHistoryItemTVCell.swift
@@ -14,13 +14,11 @@ final class SearchHistoryItemTVCell: BaseTableViewCell {
     
     private let clockImageView = UIImageView().build { builder in
         builder.tintColor(.meaningBlack)
-            .image(
-                UIImage(systemName: "clock")?
-                    .withConfiguration(
-                        UIImage.SymbolConfiguration(
-                            font: DesignConstant.Font.large.with(weight: .bold)
-                        )
-                    )
+            .image(UIImage(systemName: "clock"))
+            .preferredSymbolConfiguration(
+                UIImage.SymbolConfiguration(
+                    font: DesignConstant.Font.large.with(weight: .heavy)
+                )
             )
     }
     
@@ -73,7 +71,7 @@ final class SearchHistoryItemTVCell: BaseTableViewCell {
         }
         
         queryLabel.snp.makeConstraints { make in
-            make.centerY.equalTo(contentView)
+            make.verticalEdges.equalTo(contentView).inset(15)
             make.leading.equalTo(clockImageView.snp.trailing)
                 .offset(20)
             make.trailing.equalTo(removeButton.snp.leading)

--- a/MeaningOut/Sources/Presentation/MainTab/TabBarController.swift
+++ b/MeaningOut/Sources/Presentation/MainTab/TabBarController.swift
@@ -40,7 +40,7 @@ extension TabBarController {
         private var viewController: UIViewController {
             switch self {
             case .search:
-                SearchViewController()
+                SearchHistoryViewController()
             case .setting:
                 SettingViewController()
             }

--- a/MeaningOut/Sources/Presentation/Onboarding/OnboardingMainViewController.swift
+++ b/MeaningOut/Sources/Presentation/Onboarding/OnboardingMainViewController.swift
@@ -21,14 +21,15 @@ final class OnboardingMainViewController: BaseViewController {
             .contentMode(.scaleAspectFit)
     }
     
-    private lazy var startButton = LargeButton(title: "시작하기")
-        .build { builder in
-            builder.addTarget(
-                self,
-                action: #selector(startButtonTapped),
-                for: .touchUpInside
-            )
-        }
+    private lazy var startButton = LargeButton(
+        title: "시작하기"
+    ).build { builder in
+        builder.addTarget(
+            self,
+            action: #selector(startButtonTapped),
+            for: .touchUpInside
+        )
+    }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)

--- a/MeaningOut/Sources/Utility/Debugging/Logger.swift
+++ b/MeaningOut/Sources/Utility/Debugging/Logger.swift
@@ -37,7 +37,6 @@ enum Logger {
             file, line, function, String(describing: content)
         )
     }
-
     
     static func error(
         _ error: Error,
@@ -69,5 +68,23 @@ enum Logger {
                 file, line, function, String(describing: error)
             )
         }
+    }
+    
+    static func retainCount(
+        _ target: AnyObject,
+        file: String = #fileID,
+        line: Int = #line,
+        function: String = #function
+    ) {
+        let retainCount = CFGetRetainCount(target)
+        os_log(
+            """
+            📍 %{public}@ at line %{public}d - %{public}@ 📍
+            ➡️ %{public}@'s Retain Count: %{public}ld ⬅️
+            """,
+            log: logger,
+            type: .debug,
+            file, line, function, String(describing: target), retainCount
+        )
     }
 }

--- a/MeaningOut/Sources/Utility/Network/DataRequest.swift
+++ b/MeaningOut/Sources/Utility/Network/DataRequest.swift
@@ -1,0 +1,79 @@
+//
+//  DataRequest.swift
+//  MeaningOut
+//
+//  Created by gnksbm on 6/29/24.
+//
+
+import Foundation
+
+protocol DataRequest: AnyObject {
+    func didReceive(data: Data)
+    func didReceive(error: Error)
+}
+
+final class AnyDataRequest<T: Decodable>: DataRequest {
+    let task: URLSessionTask?
+    
+    private var onNextEvent: ((T) -> Void)?
+    private var onErrorEvent: ((Error) -> Void)?
+    private var onCompleteEvent: (() -> Void)?
+    
+    init(task: URLSessionTask?) {
+        self.task = task
+    }
+    
+    deinit {
+        onCompleteEvent?()
+    }
+    
+    func decode<Item: Decodable>(
+        type: Item.Type
+    ) -> AnyDataRequest<Item> {
+        let request = AnyDataRequest<Item>(task: task)
+        if let task {
+            RequestStorage.replaceRequest(
+                taskID: task.taskIdentifier,
+                request: request
+            )
+        }
+        return request
+    }
+    
+    func receive(
+        onNext: @escaping (T) -> Void,
+        onError: @escaping (Error) -> Void = { _ in },
+        onComplete: @escaping () -> Void = { }
+    ) {
+        task?.resume()
+        onNextEvent = onNext
+        onErrorEvent = onError
+        onCompleteEvent = onComplete
+    }
+    
+    func didReceive(data: Data) {
+        if let data = data as? T {
+            onNextEvent?(data)
+        } else {
+            do {
+                let result = try JSONDecoder().decode(T.self, from: data)
+                self.onNextEvent?(result)
+            } catch {
+                didReceive(error: error)
+            }
+        }
+    }
+    
+    func didReceive(error: Error) {
+        onErrorEvent?(error)
+    }
+    
+    @discardableResult
+    func logRetainCount(
+        file: String = #fileID,
+        line: Int = #line,
+        function: String = #function
+    ) -> Self {
+        return self
+    }
+}

--- a/MeaningOut/Sources/Utility/Network/DataRequest.swift
+++ b/MeaningOut/Sources/Utility/Network/DataRequest.swift
@@ -40,15 +40,17 @@ final class AnyDataRequest<T: Decodable>: DataRequest {
         return request
     }
     
+    @discardableResult
     func receive(
         onNext: @escaping (T) -> Void,
         onError: @escaping (Error) -> Void = { _ in },
         onComplete: @escaping () -> Void = { }
-    ) {
+    ) -> Self {
         task?.resume()
         onNextEvent = onNext
         onErrorEvent = onError
         onCompleteEvent = onComplete
+        return self
     }
     
     func didReceive(data: Data) {
@@ -66,6 +68,13 @@ final class AnyDataRequest<T: Decodable>: DataRequest {
     
     func didReceive(error: Error) {
         onErrorEvent?(error)
+    }
+    
+    func cancel() {
+        onNextEvent = nil
+        onErrorEvent = nil
+        onCompleteEvent = nil
+        task?.cancel()
     }
     
     @discardableResult

--- a/MeaningOut/Sources/Utility/Network/NetworkError.swift
+++ b/MeaningOut/Sources/Utility/Network/NetworkError.swift
@@ -1,0 +1,34 @@
+//
+//  NetworkError.swift
+//  MeaningOut
+//
+//  Created by gnksbm on 6/29/24.
+//
+
+import Foundation
+
+enum NetworkError: LocalizedError {
+    case requestFailed(Error)
+    case noResponse
+    case invalidResponseType
+    case statusCodeError(statusCode: Int)
+    case noData
+    case decodingError(type: Decodable.Type, error: Error)
+    
+    var errorDescription: String? {
+        switch self {
+        case .requestFailed(let error):
+            "요청에 실패하였습니다.\n에러: \(error.localizedDescription)"
+        case .noResponse:
+            "서버로부터 응답을 받지 못했습니다."
+        case .invalidResponseType:
+            "응답 형식이 유효하지 않습니다."
+        case .statusCodeError(let statusCode):
+            "잘못된 상태 코드입니다 - \(statusCode)"
+        case .noData:
+            "데이터를 받지 못했습니다."
+        case .decodingError(let type, let error):
+            "\(type)으로 디코딩에 실패하였습니다.\n에러: \(error.localizedDescription)"
+        }
+    }
+}

--- a/MeaningOut/Sources/Utility/Network/NetworkService.swift
+++ b/MeaningOut/Sources/Utility/Network/NetworkService.swift
@@ -1,0 +1,70 @@
+//
+//  NetworkService.swift
+//  MeaningOut
+//
+//  Created by gnksbm on 6/27/24.
+//
+
+import Foundation
+
+final class NetworkService: NSObject {
+    static let shared = NetworkService()
+    
+    static let session = URLSession(
+        configuration: .default,
+        delegate: shared,
+        delegateQueue: nil
+    )
+    
+    private override init() { }
+    
+    func request(
+        endpoint: EndpointRepresentable
+    ) -> AnyDataRequest<Data> {
+        do {
+            let urlRequest = try endpoint.asURLRequest()
+            let task = Self.session.dataTask(with: urlRequest)
+            return RequestStorage.makeRequest(task: task)
+        } catch {
+            let request = AnyDataRequest<Data>(task: nil)
+            request.didReceive(error: error)
+            return request
+        }
+    }
+}
+
+extension NetworkService: URLSessionDataDelegate {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceiveInformationalResponse response: HTTPURLResponse
+    ) {
+        let request = RequestStorage.getRequest(taskID: task.taskIdentifier)
+        guard 200..<300 ~= response.statusCode else {
+            request?.didReceive(error: NetworkError.invalidResponseType)
+            return
+        }
+    }
+    
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive data: Data
+    ) {
+        RequestStorage.getRequest(taskID: dataTask.taskIdentifier)?
+            .didReceive(data: data)
+    }
+    
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: (any Error)?
+    ) {
+        if let error {            
+            RequestStorage.getRequest(taskID: task.taskIdentifier)?
+                .didReceive(error: NetworkError.requestFailed(error))
+        } else {
+            RequestStorage.removeRequest(taskID: task.taskIdentifier)
+        }
+    }
+}

--- a/MeaningOut/Sources/Utility/Network/RequestStorage.swift
+++ b/MeaningOut/Sources/Utility/Network/RequestStorage.swift
@@ -1,0 +1,30 @@
+//
+//  RequestStorage.swift
+//  MeaningOut
+//
+//  Created by gnksbm on 6/29/24.
+//
+
+import Foundation
+
+enum RequestStorage {
+    private static var storage = [Int: DataRequest]()
+    
+    static func makeRequest(task: URLSessionTask) -> AnyDataRequest<Data> {
+        let request = AnyDataRequest<Data>(task: task)
+        storage[task.taskIdentifier] = request
+        return request
+    }
+    
+    static func replaceRequest(taskID: Int, request: DataRequest) {
+        storage[taskID] = request
+    }
+    
+    static func getRequest(taskID: Int) -> DataRequest? {
+        storage[taskID]
+    }
+    
+    static func removeRequest(taskID: Int) {
+        storage.removeValue(forKey: taskID)
+    }
+}


### PR DESCRIPTION
## 작업내용
### 네트워크 로직 객체 분리
- NetworkService
  - request(endpoint: EndpointRepresentable) -> AnyDataRequest<Data>
    - 네트워크 응답을 관리하거나 요청을 취소하는 AnyDataRequest<Data> 객체 생성 및 반환
- RequestStorage 
  - AnyDataRequest의 생명주기를 관리하기 위한 저장 객체
- DataRequest
  - AnyDataRequest는 타입에서 제네릭을 사용하고
  RequestStorage에 저장될 Dictionary의 Value 타입으로는 부적합하기에 추상화
  - NetworkService에서 사용할 didReceive 메서드 선언
- AnyDataRequest
  - receive()
    - RxSwift와 유사한 형태로 통신 결과 처리
    - onNext: 응답이 성공할 경우의 처리 구문
      - 기본 반환형은 Data이고 decode 메서드를 사용해 핸들링할 타입을 변환 가능
        - 디코딩이 실패시 onError구문 실행
    - onError: 응답이 성공할 경우의 에러처리 구문
    - onComplete: 응답이 종료되고 AnyDataRequest의 생명주기가 종료될 때 실행될 구문
  - cancel()
    - receive 메서드로 반환반은 이벤트 핸들링을 취소
### 기타 구현
- SearchViewController -> SearchHistoryViewController로 이름 수정
  - Search라는 이름이 모호하기에 명확하게 수정
- Logger.retainCount(_: AnyObject)
  - class 객체의 참조 카운트를 디버깅 하는 메서드
- SearchHistroyVC의 TableViewCell의 높이가 명확하지 않아 UI 로직 수정
  - 시계 아이콘의 Font 수정
- 코드 스타일 수정
## 관련 이슈
close #11
